### PR TITLE
Mark Unknown Horizons as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This Flatpak is no longer maintained."
+}


### PR DESCRIPTION
> This Flatpak is no longer maintained.

This game uses an outdated runtime that has been EOL for years.

> LANG=EN flatpak remote-info flathub --system org.freedesktop.Platform//21.08
> 
> End-of-life: org.freedesktop.Platform 21.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
> Date: 2023-10-02 18:42:24 +0000 

